### PR TITLE
Responsive UI

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -17,9 +17,9 @@ export default function App({ Component, pageProps }) {
           font-family: ${inter.style.fontFamily};
         }
       `}</style>
-      <main className={`${inter.variable} font-inter`}>
+      <div className={`${inter.variable} font-inter`}>
         <Component {...pageProps} />
-      </main>
+      </div>
     </>
   );
 }

--- a/styles/global.css
+++ b/styles/global.css
@@ -298,6 +298,37 @@ nav > a:first-child:hover {
   color: var(--gray-900);
 }
 
+
+/* layout */
+
+/* let header and content-wrapper be 100% so they stay flush with the window-sides */
+.nextra-nav-container nav {
+  max-width: 100%;
+}
+div:has(> .nextra-sidebar-container) {
+  max-width: 100%;
+}
+
+.nextra-content main {
+  max-width: 52rem;
+  box-sizing: content-box; /* so max-width is actual content-width without including a set padding */
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+  .nextra-content main {
+    padding-right: 2rem;
+    padding-left: 2rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .nextra-content main {
+    padding-right: 3rem;
+    padding-left: 3rem;
+  }
+}
+
+
 /* toc */
 .nextra-toc ul li {
   margin: 0; /* override nextra */

--- a/styles/global.css
+++ b/styles/global.css
@@ -251,17 +251,17 @@
 }
 
 .nextra-content h1 {
-  @apply text-h1 mt-8;
+  @apply text-h1 mt-8 max-w-3xl;
   color: var(--text-title);
 }
 
 .nextra-content h2 {
-  @apply text-h2 pb-3;
+  @apply text-h2 pb-3 max-w-3xl;
   color: var(--text-title);
 }
 
 .nextra-content h3 {
-  @apply text-h3;
+  @apply text-h3 max-w-3xl;
   color: var(--text-title);
 }
 
@@ -282,6 +282,7 @@
 nav > a:first-child:hover {
   opacity: 1;
 }
+
 
 /* sidebar */
 .nextra-sidebar-container li.active a {

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -36,7 +36,9 @@ const config: DocsThemeConfig = {
     // https://mdxjs.com/table-of-components/
     pre: Pre,
     code: Code,
-    p: (props) => <p className="nx-mt-5 first:nx-mt-0 leading-6" {...props} />,
+    p: (props) => (
+      <p className="max-w-3xl nx-mt-5 first:nx-mt-0 leading-6" {...props} />
+    ),
     table: Table,
     th: Th,
     tr: Tr,


### PR DESCRIPTION
Adjust layout so the sidebars stay flush with the window-sides, making the content stand out more.

- change _ui-width_ to 100%
- adjust _paddings_ according to Design specifications
- adjust _running-text-width_ and _content-max-width_
- replace second _main_ tag with a `div` to increase usability by leaving only one _main_-element