### PR TITLE
Mobile improvements

### DIFF
--- a/components/InteractiveForm.tsx
+++ b/components/InteractiveForm.tsx
@@ -529,7 +529,7 @@ export const InteractiveForm = () => {
             </div>
           </div>
           {/* content */}
-          <div className="h-[20rem] md:h-[30rem] py-5 px-4 overflow-y-auto text-gray-200">
+          <div className="h-[55vw] md:h-[30rem] py-5 px-4 overflow-y-auto text-gray-200">
             {notStarted && (
               <CliTypeWriter
                 sequence={["Please submit the registration."]}
@@ -769,7 +769,7 @@ export const InteractiveForm = () => {
           </div>
         </div>
         {/* --- animation area --- */}
-        <div className="h-[25rem] md:h-full px-10 svg-register flex items-end md:items-center justify-center grow">
+        <div className="h-[55vw] md:h-full px-10 svg-register flex items-end md:items-center justify-center grow">
           <ClientServer
             serverActive={serverIsActive}
             clientActive={clientIsActive}

--- a/components/blocks/BlockWrapper.tsx
+++ b/components/blocks/BlockWrapper.tsx
@@ -11,7 +11,7 @@ export const BlockWrapper: React.FC<BlockWrapperProps> = ({
   return (
     <div
       className={cn(
-        "h-[50rem] max-w-[67.5rem] mx-auto flex items-center",
+        "min-h-[50rem] max-w-[67.5rem] mx-auto flex items-center",
         className
       )}
       {...props}

--- a/components/blocks/Example.tsx
+++ b/components/blocks/Example.tsx
@@ -1,3 +1,4 @@
+import cn from "clsx";
 import { ImageData } from "../../types/types";
 import { DisplayHeading } from "../DisplayHeading";
 import { P } from "../P";
@@ -8,6 +9,7 @@ export type ExampleProps = {
   text: string;
   image?: ImageData;
   children?: React.ReactNode;
+  className?: string;
 };
 
 export const Example: React.FC<ExampleProps> = ({
@@ -15,10 +17,11 @@ export const Example: React.FC<ExampleProps> = ({
   text,
   image,
   children,
+  className,
   ...props
 }) => {
   return (
-    <BlockWrapper className="text-center" {...props}>
+    <BlockWrapper className={cn("text-center", className)} {...props}>
       <DisplayHeading tag="h3" className="mb-4">
         {header}
       </DisplayHeading>


### PR DESCRIPTION
Minor fixes for mobile container heights. 

- fix `Example` _className_ handling
- use _min-height_ instead of fixed height for `BlockWrapper` so content can expand when needed
- adjust mobile-heights for _cli_ and _graphic_ containers inside of `InteractiveForm` component